### PR TITLE
libevent2022: Revert part of f0e6d2b

### DIFF
--- a/opal/mca/event/libevent2022/configure.m4
+++ b/opal/mca/event/libevent2022/configure.m4
@@ -163,10 +163,6 @@ AC_DEFUN([MCA_opal_event_libevent2022_DO_THE_CONFIG], [
         event_args="$event_args --enable-debug-mode"
     fi
 
-    if test "$WANT_DEBUG" = 1; then
-      CFLAGS="-DOPAL_DEBUG $CFLAGS"
-    fi
-
     AC_MSG_RESULT([$event_args])
 
     OPAL_CONFIG_SUBDIR([$libevent_basedir/libevent],

--- a/opal/mca/event/libevent2022/libevent/event.c
+++ b/opal/mca/event/libevent2022/libevent/event.c
@@ -1567,7 +1567,7 @@ event_base_loop(struct event_base *base, int flags)
 
 	if (base->running_loop) {
 /*****   OMPI change   ****/
-#ifdef OPAL_DEBUG
+#if OPAL_ENABLE_DEBUG
 		event_warnx("%s: reentrant invocation.  Only one event_base_loop"
 		    " can run on each event_base at once.", __func__);
 #endif

--- a/orte/util/proc_info.h
+++ b/orte/util/proc_info.h
@@ -61,7 +61,8 @@ typedef uint32_t orte_proc_type_t;
 #define ORTE_PROC_DVM           0x0102   // DVM + daemon
 #define ORTE_PROC_IOF_ENDPT     0x1000
 #define ORTE_PROC_SCHEDULER     0x2000
-#define ORTE_PROC_MASTER        0x4004   // Master + HNP
+#define ORTE_PROC_MASTER_ACTUAL 0x4000
+#define ORTE_PROC_MASTER        (ORTE_PROC_MASTER_ACTUAL + ORTE_PROC_HNP)
 
 #define ORTE_PROC_IS_SINGLETON      (ORTE_PROC_SINGLETON & orte_process_info.proc_type)
 #define ORTE_PROC_IS_DAEMON         (ORTE_PROC_DAEMON & orte_process_info.proc_type)
@@ -75,7 +76,7 @@ typedef uint32_t orte_proc_type_t;
 #define ORTE_PROC_IS_DVM            (ORTE_PROC_DVM & orte_process_info.proc_type)
 #define ORTE_PROC_IS_IOF_ENDPT      (ORTE_PROC_IOF_ENDPT & orte_process_info.proc_type)
 #define ORTE_PROC_IS_SCHEDULER      (ORTE_PROC_SCHEDULER & orte_process_info.proc_type)
-#define ORTE_PROC_IS_MASTER         (0x4000 & orte_process_info.proc_type)
+#define ORTE_PROC_IS_MASTER         (ORTE_PROC_MASTER_ACTUAL & orte_process_info.proc_type)
 
 
 /**


### PR DESCRIPTION
Minor addendum to open-mpi/ompi#1109.

Revert the change in opal/mca/event/libevent2022/configure.m4, and use an already-existing preprocessor macro (i.e., use OPAL_ENABLE_DEBUG; don't create a new OPAL_DEBUG).