### PR TITLE
Minor updates / tweaks to new mpirun timeout functionality

### DIFF
--- a/orte/mca/odls/odls_types.h
+++ b/orte/mca/odls/odls_types.h
@@ -9,7 +9,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2010-2011 Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
@@ -80,8 +80,8 @@ typedef uint8_t orte_daemon_cmd_flag_t;
 /* add procs for the DVM */
 #define ORTE_DAEMON_DVM_ADD_PROCS           (orte_daemon_cmd_flag_t) 30
 
-/* for debug purposes, get stacktraces from all application procs */
-#define ORTE_DAEMON_GET_STACKTRACES         (orte_daemon_cmd_flag_t) 31
+/* for debug purposes, get stack traces from all application procs */
+#define ORTE_DAEMON_GET_STACK_TRACES        (orte_daemon_cmd_flag_t) 31
 
 /*
  * Struct written up the pipe from the child to the parent.

--- a/orte/mca/rml/rml_types.h
+++ b/orte/mca/rml/rml_types.h
@@ -164,7 +164,7 @@ BEGIN_C_DECLS
 #define ORTE_RML_TAG_NOTIFICATION           59
 
 /* stacktrace for debug */
-#define ORTE_RML_TAG_STACKTRACE             60
+#define ORTE_RML_TAG_STACK_TRACE            60
 
 #define ORTE_RML_TAG_MAX                   100
 

--- a/orte/mca/schizo/ompi/schizo_ompi.c
+++ b/orte/mca/schizo/ompi/schizo_ompi.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -99,9 +99,9 @@ static opal_cmd_line_init_t cmd_line_init[] = {
     { NULL, '\0', "report-state-on-timeout", "report-state-on-timeout", 0,
       &orte_cmd_options.report_state_on_timeout, OPAL_CMD_LINE_TYPE_BOOL,
       "Report all job and process states upon timeout" },
-    { NULL, '\0', "get-stacktraces", "get-stacktraces", 0,
-      &orte_cmd_options.get_stacktraces, OPAL_CMD_LINE_TYPE_BOOL,
-      "Get stacktraces of all application procs on timeout" },
+    { NULL, '\0', "get-stack-traces", "get-stack-traces", 0,
+      &orte_cmd_options.get_stack_traces, OPAL_CMD_LINE_TYPE_BOOL,
+      "Get stack traces of all application procs on timeout" },
 
 
     /* exit status reporting */

--- a/orte/orted/orted_comm.c
+++ b/orte/orted/orted_comm.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007-2012 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
@@ -47,6 +47,7 @@
 #include "opal/mca/base/base.h"
 #include "opal/util/output.h"
 #include "opal/util/opal_environ.h"
+#include "opal/util/path.h"
 #include "opal/runtime/opal.h"
 #include "opal/runtime/opal_progress.h"
 #include "opal/dss/dss.h"
@@ -113,6 +114,7 @@ void orte_daemon_recv(int status, orte_process_name_t* sender,
     orte_grpcomm_signature_t *sig;
     FILE *fp;
     char gscmd[256], path[1035], *pathptr;
+    char string[256], *string_ptr = string;
 
     /* unpack the command */
     n = 1;
@@ -1077,20 +1079,48 @@ void orte_daemon_recv(int status, orte_process_name_t* sender,
         /* prep the response */
         answer = OBJ_NEW(opal_buffer_t);
         pathptr = path;
+
+        // Try to find the "gstack" executable.  Failure to find the
+        // executable will be handled below, because the receiver
+        // expects to have the process name, hostname, and PID in the
+        // buffer before finding an error message.
+        char *gstack_exec;
+        gstack_exec = opal_find_absolute_path("gstack");
+
         /* hit each local process with a gstack command */
         for (i=0; i < orte_local_children->size; i++) {
             if (NULL != (proct = (orte_proc_t*)opal_pointer_array_get_item(orte_local_children, i)) &&
                 ORTE_FLAG_TEST(proct, ORTE_PROC_FLAG_ALIVE)) {
                 relay_msg = OBJ_NEW(opal_buffer_t);
-                if (OPAL_SUCCESS != opal_dss.pack(relay_msg, &proct->name, 1, ORTE_NAME)) {
+                if (OPAL_SUCCESS != opal_dss.pack(relay_msg, &proct->name, 1, ORTE_NAME) ||
+                    OPAL_SUCCESS != opal_dss.pack(relay_msg, &proct->node->name, 1, OPAL_STRING) ||
+                    OPAL_SUCCESS != opal_dss.pack(relay_msg, &proct->pid, 1, OPAL_PID)) {
                     OBJ_RELEASE(relay_msg);
                     break;
                 }
-                (void)snprintf(gscmd, 256, "gstack %lu", (unsigned long)proct->pid);
-                fp = popen(gscmd, "r");
-                if (NULL == fp) {
-                    /* can't run it - just return the buffer so
-                     * the HNP doesn't hang */
+
+                // If we were able to find the gstack executable,
+                // above, then run the command here.
+                fp = NULL;
+                if (NULL != gstack_exec) {
+                    (void) snprintf(gscmd, sizeof(gscmd), "%s %lu",
+                                    gstack_exec, (unsigned long) proct->pid);
+                    fp = popen(gscmd, "r");
+                }
+
+                // If either we weren't able to find or run the gstack
+                // exectuable, send back a nice error message here.
+                if (NULL == gstack_exec || NULL == fp) {
+                    (void) snprintf(string, sizeof(string),
+                                    "Failed to %s \"%s\" on %s to obtain stack traces",
+                                    (NULL == gstack_exec) ? "find" : "run",
+                                    (NULL == gstack_exec) ? "gstack" : gstack_exec,
+                                    proct->node->name);
+                    if (OPAL_SUCCESS ==
+                        opal_dss.pack(relay_msg, &string_ptr, 1, OPAL_STRING)) {
+                        opal_dss.pack(answer, &relay_msg, 1, OPAL_BUFFER);
+                    }
+                    OBJ_RELEASE(relay_msg);
                     break;
                 }
                 /* Read the output a line at a time and pack it for transmission */

--- a/orte/orted/orted_comm.c
+++ b/orte/orted/orted_comm.c
@@ -1075,7 +1075,7 @@ void orte_daemon_recv(int status, orte_process_name_t* sender,
         }
         break;
 
-    case ORTE_DAEMON_GET_STACKTRACES:
+    case ORTE_DAEMON_GET_STACK_TRACES:
         /* prep the response */
         answer = OBJ_NEW(opal_buffer_t);
         pathptr = path;
@@ -1144,7 +1144,7 @@ void orte_daemon_recv(int status, orte_process_name_t* sender,
         }
         /* always send our response */
         if (0 > (ret = orte_rml.send_buffer_nb(ORTE_PROC_MY_HNP, answer,
-                                               ORTE_RML_TAG_STACKTRACE,
+                                               ORTE_RML_TAG_STACK_TRACE,
                                                orte_rml_send_callback, NULL))) {
             ORTE_ERROR_LOG(ret);
             OBJ_RELEASE(answer);
@@ -1219,8 +1219,8 @@ static char *get_orted_comm_cmd_str(int command)
     case ORTE_DAEMON_DVM_ADD_PROCS:
         return strdup("ORTE_DAEMON_DVM_ADD_PROCS");
 
-    case ORTE_DAEMON_GET_STACKTRACES:
-        return strdup("ORTE_DAEMON_GET_STACKTRACES");
+    case ORTE_DAEMON_GET_STACK_TRACES:
+        return strdup("ORTE_DAEMON_GET_STACK_TRACES");
 
     default:
         return strdup("Unknown Command!");

--- a/orte/orted/orted_submit.h
+++ b/orte/orted/orted_submit.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -94,7 +95,7 @@ struct orte_cmd_options_t {
     bool staged_exec;
     int timeout;
     bool report_state_on_timeout;
-    bool get_stacktraces;
+    bool get_stack_traces;
 };
 typedef struct orte_cmd_options_t orte_cmd_options_t;
 ORTE_DECLSPEC extern orte_cmd_options_t orte_cmd_options;

--- a/orte/tools/orterun/help-orterun.txt
+++ b/orte/tools/orterun/help-orterun.txt
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2007-2010 Cisco Systems, Inc. All rights reserved.
+# Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012      Oak Ridge National Labs.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -647,9 +647,9 @@ reached:
 
   MPIEXEC_TIMEOUT: %d seconds
 
-The job will now be aborted. Please check your code and/or
-adjust/remove the job execution time limit (as specified
-by MPIEXEC_TIMEOUT in your environment or -timeout on the cmd line).
+The job will now be aborted.  Please check your code and/or
+adjust/remove the job execution time limit (as specified by
+MPIEXEC_TIMEOUT in your environment or --timeout on the command line).
 #
 [orterun:conflict-env-set]
 ERROR: You have attempted to pass environment variables to Open MPI
@@ -672,7 +672,7 @@ Your computer's name (see uname -n).
 [orterun:timeoutconflict]
 Conflicting requests for timeout were given:
 
-  -timeout command line option:  %d
+  --timeout command line option: %d
   MPIEXEC_TIMEOUT envar:         %s
 
 Only one method should be provided, or else they must agree. Please


### PR DESCRIPTION
Yo @rhc54 --

I made a few minor updates and tweaks to the cool new timeout/stack trace functionality.  There's 3 commits -- the first one is the good one, the second two are just Jeff-is-a-type-A-personality commits -- feel free to take them or not.  😄 

1. Minor improvements on the new mechanism:
    1. Deliberately search for `gstack` in $PATH, and send back a specific error message if it can't be found.
    1. Send back a different error message if `gstack` fails to run.  **Motivation:** I noticed that if `gstack` isn't in your $PATH, `popen()` still returns a non-NULL fp, and you just get a blank stack trace back up at mpirun.  So I wanted to clearly call out these two different errors for the user.
    1. Print a "Waiting for stack traces (this may take a few moments)..." kind of message while waiting for the stack traces to arrive.
    1. Also include the hostname and PID for each stack trace that we print out.

1. Trivial word smything on the help-orterun message.

1. Trivial word smything: "stacktrace" -> "stack trace".