### PR TITLE
use pkg-config to find flux PMI library

### DIFF
--- a/opal/mca/pmix/flux/Makefile.am
+++ b/opal/mca/pmix/flux/Makefile.am
@@ -27,12 +27,12 @@ endif
 mcacomponentdir = $(opallibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pmix_flux_la_SOURCES = $(sources)
-mca_pmix_flux_la_CPPFLAGS = $(flux_CPPFLAGS)
-mca_pmix_flux_la_LDFLAGS = -module -avoid-version $(flux_LDFLAGS)
-mca_pmix_flux_la_LIBADD = $(flux_LIBS)
+mca_pmix_flux_la_CPPFLAGS = $(FLUX_PMI_CFLAGS)
+mca_pmix_flux_la_LDFLAGS = -module -avoid-version
+mca_pmix_flux_la_LIBADD = $(FLUX_PMI_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pmix_flux_la_SOURCES =$(sources)
-libmca_pmix_flux_la_CPPFLAGS = $(flux_CPPFLAGS)
-libmca_pmix_flux_la_LDFLAGS = -module -avoid-version $(flux_LDFLAGS)
-libmca_pmix_flux_la_LIBADD = $(flux_LIBS)
+libmca_pmix_flux_la_CPPFLAGS = $(FLUX_PMI_CFLAGS)
+libmca_pmix_flux_la_LDFLAGS = -module -avoid-version
+libmca_pmix_flux_la_LIBADD = $(FLUX_PMI_LIBS)

--- a/opal/mca/pmix/flux/configure.m4
+++ b/opal/mca/pmix/flux/configure.m4
@@ -11,154 +11,53 @@
 # MCA_pmix_flux_CONFIG([action-if-found], [action-if-not-found])
 # -----------------------------------------------------------
 AC_DEFUN([MCA_opal_pmix_flux_CONFIG], [
+
     AC_CONFIG_FILES([opal/mca/pmix/flux/Makefile])
 
     AC_ARG_WITH([flux-pmi],
-                [AC_HELP_STRING([--with-flux-pmi(=DIR)],
-                                [Build Flux PMI support, optionally adding DIR to the search path (default: no)])],
-                                [], with_flux_pmi=no)
+                [AC_HELP_STRING([--with-flux-pmi],
+                                [Build Flux PMI support (default: yes)])])
 
-    AC_ARG_WITH([flux-pmi-libdir],
-                [AC_HELP_STRING([--with-flux-pmi-libdir(=DIR)],
-                                [Look for libpmi in the given directory, DIR/lib or DIR/lib64])])
+    AC_ARG_WITH([flux-pmi-library],
+                [AC_HELP_STRING([--with-flux-pmi-library],
+                                [Link Flux PMI support with PMI library at build time.  Otherwise the library is opened at runtime at location specified by FLUX_PMI_LIBRARY_PATH environment variable.  Use this option to enable Flux support when building statically or without dlopen support (default: no)])])
 
-    flux_pmi_install_dir=
-    flux_pmi_lib_dir=
-    default_flux_pmi_loc=
-    default_flux_pmi_libloc=
 
-    # save flags
-    flux_save_CPPFLAGS=$CPPFLAGS
-    flux_save_LDFLAGS=$LDFLAGS
-    flux_save_LIBS=$LIBS
-    flux_hdr_happy=
-
-    AC_MSG_CHECKING([if user requested Flux PMI support])
-    AS_IF([test "$with_flux_pmi" = "no"],
+    # pkg-config check aborts configure on failure
+    AC_MSG_CHECKING([if user wants Flux support to link against PMI library])
+    AS_IF([test "x$with_flux_pmi_library" != "xyes"],
           [AC_MSG_RESULT([no])
            $3],
           [AC_MSG_RESULT([yes])
-           # cannot use OPAL_CHECK_PACKAGE as its backend header
-           # support appends "include" to the path, which may not
-           # work with flux if it follows slurm's practice :-(
-           AS_IF([test ! -z "$with_flux_pmi" && test "$with_flux_pmi" != "yes"],
-                 [flux_pmi_install_dir=$with_flux_pmi
-                  default_flux_pmi_loc=no],
-                 [flux_pmi_install_dir=/usr
-                  default_flux_pmi_loc=yes])
-           AS_IF([test ! -z "$with_flux_pmi_libdir"],
-                 [flux_pmi_lib_dir=$with_flux_pmi_libdir
-                  default_flux_pmi_libloc=no],
-                 [flux_pmi_lib_dir=$flux_pmi_install_dir
-          AS_IF([test "$default_flux_pmi_loc" = "no"],
-                [default_flux_pmi_libloc=no],
-                [default_flux_pmi_libloc=yes])])
+          PKG_CHECK_MODULES([FLUX_PMI], [flux-pmi], [], [])
+          have_flux_pmi_library=yes
+          AC_DEFINE([HAVE_FLUX_PMI_LIBRARY], [1],
+                    [Flux support builds against external PMI library])
+          ])
 
-           # check for the header - first in exact path */
-           AC_MSG_CHECKING([for pmi.h in $flux_pmi_install_dir])
-           AS_IF([test -f $flux_pmi_install_dir/pmi.h],
-                 [AC_MSG_RESULT([found])
-                  flux_hdr_happy=yes
-                  flux_CPPFLAGS="-I$flux_pmi_install_dir"],
-                 [AC_MSG_RESULT([not found])
-                  AC_MSG_CHECKING([for pmi.h in $flux_pmi_install_dir/include])
-                  AS_IF([test -f $flux_pmi_install_dir/include/pmi.h],
-                        [AC_MSG_RESULT([found])
-                         flux_hdr_happy=yes
-                         flux_CPPFLAGS="-I$flux_pmi_install_dir/include"],
-                        [AC_MSG_RESULT([not found])
-                         flux_hdr_happy=no])])
+    AC_MSG_CHECKING([if Flux support allowed to use dlopen])
+    AS_IF([test $OPAL_ENABLE_DLOPEN_SUPPORT -eq 1 && test "x$compile_mode" = "xdso"],
+          [AC_MSG_RESULT([yes])
+          flux_can_dlopen=yes
+          ],
+          [AC_MSG_RESULT([no])
+          ])
 
-           # check for library and function
-           flux_lib_happy=
-           LIBS="$LIBS -lpmi"
-
-           # check for the library in the given location in case
-           # an exact path was given
-           AC_MSG_CHECKING([for libpmi in $flux_pmi_lib_dir])
-           files=`ls $flux_pmi_lib_dir/libpmi.* 2> /dev/null | wc -l`
-           AS_IF([test "$files" -gt "0"],
-                 [AC_MSG_RESULT([found])
-                  LDFLAGS="$LDFLAGS -L$flux_pmi_lib_dir"
-                  AC_CHECK_LIB([pmi], [PMI_Init],
-                               [flux_lib_happy=yes
-                                flux_LDFLAGS=-L$flux_pmi_lib_dir
-                                flux_rpath=$flux_pmi_lib_dir],
-                               [flux_lib_happy=no])],
-                 [flux_lib_happy=no
-                  AC_MSG_RESULT([not found])])
-
-           # check for presence of lib64 directory - if found, see if the
-           # desired library is present and matches our build requirements
-           files=`ls $flux_pmi_lib_dir/lib64/libpmi.* 2> /dev/null | wc -l`
-           AS_IF([test "$flux_lib_happy" != "yes"],
-                 [AC_MSG_CHECKING([for libpmi in $flux_pmi_lib_dir/lib64])
-                  AS_IF([test "$files" -gt "0"],
-                        [AC_MSG_RESULT([found])
-                         LDFLAGS="$LDFLAGS -L$flux_pmi_lib_dir/lib64"
-                         AC_CHECK_LIB([pmi], [PMI_Init],
-                                      [flux_lib_happy=yes
-                                       flux_LDFLAGS=-L$flux_pmi_lib_dir/lib64
-                                       flux_rpath=$flux_pmi_lib_dir/lib64],
-                                      [flux_lib_happy=no])],
-                        [flux_lib_happy=no
-                         AC_MSG_RESULT([not found])])])
-
-           # if we didn't find lib64, or the library wasn't present or correct,
-           # then try a lib directory if present
-           files=`ls $flux_pmi_lib_dir/lib/libpmi.* 2> /dev/null | wc -l`
-           AS_IF([test "$flux_lib_happy" != "yes"],
-                 [AC_MSG_CHECKING([for libpmi in $flux_pmi_lib_dir/lib])
-                  AS_IF([test "$files" -gt "0"],
-                        [AC_MSG_RESULT([found])
-                         LDFLAGS="$LDFLAGS -L$flux_pmi_lib_dir/lib"
-                         AC_CHECK_LIB([pmi], [PMI_Init],
-                                      [flux_lib_happy=yes
-                                       flux_LDFLAGS=-L$flux_pmi_lib_dir/lib
-                                       flux_rpath=$flux_pmi_lib_dir/lib],
-                                      [flux_lib_happy=no])],
-                        [flux_lib_happy=no
-                         AC_MSG_RESULT([not found])])])
-
-           AS_IF([test "$flux_hdr_happy" = "yes" && test "$flux_lib_happy" = "yes"],
-                 [opal_enable_flux=yes
-                  AS_IF([test "$default_flux_pmi_loc" = "no"],
-                        [AC_SUBST(flux_CPPFLAGS)])
-                  AS_IF([test "$default_flux_pmi_libloc" = "no"],
-                        [AC_SUBST(flux_LDFLAGS)
-                         AC_SUBST(flux_rpath)])],
-                 [opal_enable_flux=no])
-
-           # if support was explicitly requested, then we should error out
-           # if we didn't find the required support
-           AC_MSG_CHECKING([can Flux PMI support be built])
-           AS_IF([test "$opal_enable_flux" != "yes"],
-                 [AC_MSG_RESULT([no])
-                  AC_MSG_WARN([Flux PMI support requested (via --with-flux-pmi) but pmi.h])
-                  AC_MSG_WARN([was not found in location:])
-                  AC_MSG_WARN([    $flux_pmi_install_dir/include])
-                  AC_MSG_WARN([Specified path: $with_flux_pmi])
-                  AC_MSG_WARN([OR libpmi was not found under:])
-                  AC_MSG_WARN([    $flux_pmi_lib_dir])
-                  AC_MSG_WARN([    $flux_pmi_lib_dir/lib])
-                  AC_MSG_WARN([    $flux_pmi_lib_dir/lib64])
-                  AC_MSG_WARN([Specified path: $with_flux_pmi_libdir])
-                  AC_MSG_ERROR([Aborting])],
-                 [AC_MSG_RESULT([yes])])
-           ])
-
-    # restore flags
-    CPPFLAGS=$flux_save_CPPFLAGS
-    LDFLAGS=$flux_save_LDFLAGS
-    LIBS=$flux_save_LIBS
-
+    AC_MSG_CHECKING([Checking if Flux PMI support can be built])
+    AS_IF([test "x$with_flux_pmi" != "xno" && ( test "x$have_flux_pmi_library" = "xyes" || test "x$flux_can_dlopen" = "xyes" ) ],
+          [AC_MSG_RESULT([yes])
+          opal_enable_flux=yes
+	  ],
+          [AC_MSG_RESULT([no])
+          AS_IF([test "x$with_flux_pmi" = "xyes"],
+                [AC_MSG_ERROR([Aborting since Flux PMI support was requested])
+                ])
+          ])
 
     # Evaluate succeed / fail
-    AS_IF([test "$opal_enable_flux" = "yes"],
+    AS_IF([test "x$opal_enable_flux" = "xyes"],
           [$1
            # need to set the wrapper flags for static builds
-           pmix_flux_WRAPPER_EXTRA_LDFLAGS="$flux_LDFLAGS"
-           pmix_flux_WRAPPER_EXTRA_LIBS="$flux_LIBS"],
+           pmix_flux_WRAPPER_EXTRA_LIBS="$FLUX_PMI_LIBS"],
           [$2])
-
 ])

--- a/opal/mca/pmix/flux/pmix_flux.h
+++ b/opal/mca/pmix/flux/pmix_flux.h
@@ -7,8 +7,8 @@
  * $HEADER$
  */
 
-#ifndef MCA_PMIX_S1_H
-#define MCA_PMIX_S1_H
+#ifndef MCA_PMIX_FLUX_H
+#define MCA_PMIX_FLUX_H
 
 #include "opal_config.h"
 
@@ -28,4 +28,4 @@ OPAL_DECLSPEC extern const opal_pmix_base_module_t opal_pmix_flux_module;
 
 END_C_DECLS
 
-#endif /* MCA_PMIX_S1_H */
+#endif /* MCA_PMIX_FLUX_H */

--- a/opal/mca/pmix/flux/pmix_flux_component.c
+++ b/opal/mca/pmix/flux/pmix_flux_component.c
@@ -91,7 +91,7 @@ static int pmix_flux_component_register(void)
 static int pmix_flux_component_query(mca_base_module_t **module, int *priority)
 {
     /* disqualify ourselves if we are not under Flux */
-    if (NULL == getenv("FLUX_URI")) {
+    if (NULL == getenv("FLUX_JOB_ID")) {
         *priority = 0;
         *module = NULL;
         return OPAL_ERROR;


### PR DESCRIPTION
Thanks @rhc54 for starting the ball rolling here.   @trws asked me to poke at this a bit.

This PR is not ready for merging - just wondering if the following approach is OK:

The m4 searching through various install dirs seems like it could be fragile with respect to changes that might occur in flux, given our early stage of development.  Since pkg-config is already used by ompi, any objections to having flux provide a 'flux-pmi.pc' and then just have ompi call the PKG_CHECK_MODULES macro?

A side effect is if --with-flux-pmi is selected and the pc file isn't found, it's immediately fatal when that section is reached.  I wasn't sure if that conforms to the way things are supposed to work in ompi, and it does seem like you guys run a tight ship :-)

The nice thing is then no matter what strange installation paths evolve, you can always point ompi at a .pc file with PKG_CONFIG_PATH and it should figure it out.