### PR TITLE
When opening conduit, checking for the transport preference in below …

### DIFF
--- a/orte/mca/rml/ofi/.opal_unignore
+++ b/orte/mca/rml/ofi/.opal_unignore
@@ -1,0 +1,3 @@
+anandhis
+ajayakum
+rhc

--- a/orte/mca/rml/ofi/rml_ofi_component.c
+++ b/orte/mca/rml/ofi/rml_ofi_component.c
@@ -889,31 +889,54 @@ static int rml_ofi_component_init(void)
 */
 int get_ofi_prov_id( opal_list_t *attributes)
 {
-
+    bool choose_fabric = false, choice_made = false;
     int ofi_prov_id = RML_OFI_PROV_ID_INVALID, prov_num=0;
     char *provider = NULL, *transport = NULL;
     char *ethernet="sockets", *fabric="psm2";
     struct fi_info *cur_fi;
+    char *comp_attrib = NULL;
+    char **comps;
+    int i;
 
-    /* check the list of attributes to see if we should respond
+    /* check the list of attributes in below order
      * Attribute should have ORTE_RML_TRANSPORT_ATTRIB key
-     * with values "ethernet" or "fabric"
+     * with values "ethernet" or "fabric". "fabric" is higher priority.
      * (or)  ORTE_RML_OFI_PROV_NAME key with values "socket" or "OPA"
      * if both above attributes are missing return failure
      */
-    if (orte_get_attribute(attributes, ORTE_RML_TRANSPORT_ATTRIB, (void**)&transport, OPAL_STRING) )    {
-        if( 0 == strcmp( transport, "ethernet") ) {
-            provider = ethernet;
-        } else if ( 0 == strcmp( transport, "fabric") ) {
-            provider = fabric;
+    //if (orte_get_attribute(attributes, ORTE_RML_TRANSPORT_ATTRIB, (void**)&transport, OPAL_STRING) )    {
+
+    if (orte_get_attribute(attributes, ORTE_RML_TRANSPORT_TYPE, (void**)&comp_attrib, OPAL_STRING) &&
+        NULL != comp_attrib) {
+        comps = opal_argv_split(comp_attrib, ',');
+        for (i=0; NULL != comps[i] && choice_made == false ; i++) {
+            if (NULL != strstr(ofi_transports_supported, comps[i])) {
+                if (0 == strcmp( comps[i], "ethernet")) {
+                    opal_output_verbose(20,orte_rml_base_framework.framework_output,
+                        "%s - Opening conduit using OFI ethernet/sockets provider",
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+                    opal_argv_free(comps);
+                    provider = ethernet;
+                    choose_fabric = false;
+                    choice_made = false;  /* continue to see if fabric is requested */
+                } else if ( 0 == strcmp ( comps[i], "fabric")) {
+                    opal_output_verbose(20,orte_rml_base_framework.framework_output,
+                        "%s - Opening conduit using OFI fabric provider",
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+                    opal_argv_free(comps);
+                    choose_fabric = true;
+                    provider = NULL;
+                    choice_made = true; /* fabric is highest priority so don't check for anymore */
+               }
+            }
         }
     }
     /* if from the transport we don't know which provider we want, then check for the ORTE_RML_OFI_PROV_NAME_ATTRIB */
     if ( NULL == provider) {
        orte_get_attribute(attributes, ORTE_RML_PROVIDER_ATTRIB, (void**)&provider, OPAL_STRING);
     }
-    if (NULL != provider)
-    {
+    /* either ethernet-sockets or specific is requested. Proceed to choose that provider */
+    if (NULL != provider )    {
         // loop the orte_rml_ofi.ofi_provs[] and find the provider name that matches
         for ( prov_num = 0; prov_num < orte_rml_ofi.ofi_prov_open_num && ofi_prov_id == RML_OFI_PROV_ID_INVALID ; prov_num++ ) {
             cur_fi = orte_rml_ofi.ofi_prov[prov_num].fabric_info;
@@ -922,10 +945,27 @@ int get_ofi_prov_id( opal_list_t *attributes)
                     ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),provider,cur_fi->fabric_attr->prov_name);
             if ( strcmp(provider,cur_fi->fabric_attr->prov_name) == 0) {
                 ofi_prov_id = prov_num;
+                opal_output_verbose(20,orte_rml_base_framework.framework_output,
+                  "%s - Choosing provider %s", 
+                  ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),cur_fi->fabric_attr->prov_name);
             }
         }
-
+    } else if ( choose_fabric ) {
+        // "fabric" is requested, choose the first fabric(non-ethernet)  provider 
+        for ( prov_num = 0; prov_num < orte_rml_ofi.ofi_prov_open_num && ofi_prov_id == RML_OFI_PROV_ID_INVALID ; prov_num++ ) {
+            cur_fi = orte_rml_ofi.ofi_prov[prov_num].fabric_info;
+            opal_output_verbose(20,orte_rml_base_framework.framework_output,
+               "%s -choosing fabric -> comparing %s != %s ",
+                    ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),ethernet,cur_fi->fabric_attr->prov_name);
+            if ( strcmp(ethernet, cur_fi->fabric_attr->prov_name) != 0) {
+                ofi_prov_id = prov_num;
+                opal_output_verbose(20,orte_rml_base_framework.framework_output,
+                  "%s - Choosing fabric provider %s", 
+                  ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),cur_fi->fabric_attr->prov_name);
+            }
+        }
     }
+    
 
     opal_output_verbose(20,orte_rml_base_framework.framework_output,
                     "%s - get_ofi_prov_id(), returning ofi_prov_id=%d ",
@@ -1044,17 +1084,14 @@ static orte_rml_base_module_t* open_conduit(opal_list_t *attributes)
                     "%s - ORTE_RML_TRANSPORT_TYPE = %s ",
                     ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), comp_attrib);
         comps = opal_argv_split(comp_attrib, ',');
-        for (i=0; 0 == i; i++) {
+        for (i=0; NULL != comps[i] ; i++) {
             if (NULL != strstr(ofi_transports_supported, comps[i])) {
                 /* we are a candidate,  */
                 opal_output_verbose(20,orte_rml_base_framework.framework_output,
-                    "%s - Forcibly returning ofi socket provider for ethernet transport request",
+                    "%s - Opening conduit using OFI.. ",
                     ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
                 opal_argv_free(comps);
-                OBJ_CONSTRUCT(&provider, opal_list_t);
-                orte_set_attribute(&provider, ORTE_RML_PROVIDER_ATTRIB,
-                         ORTE_ATTR_LOCAL, "sockets", OPAL_STRING);
-                return make_module(get_ofi_prov_id(&provider));
+                return make_module(get_ofi_prov_id(attributes));
             }
         }
         opal_argv_free(comps);

--- a/orte/mca/rml/ofi/rml_ofi_send.c
+++ b/orte/mca/rml/ofi/rml_ofi_send.c
@@ -415,8 +415,8 @@ static void send_msg(int fd, short args, void *cbdata)
                             "%s rml:ofi: Send failed to get peer OFI contact info from internal hash - checking modex",
                             ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
         asprintf(&pmix_key,"%s%d",
-                 orte_rml_ofi.ofi_prov[0].fabric_info->fabric_attr->prov_name,
-                 orte_rml_ofi.ofi_prov[0].ofi_prov_id);
+                 orte_rml_ofi.ofi_prov[ofi_prov_id].fabric_info->fabric_attr->prov_name,
+                 ofi_prov_id);
         OPAL_MODEX_RECV_STRING(ret, pmix_key, peer, (void**)&dest_ep_name, &dest_ep_namelen);
         free(pmix_key);
         if (OPAL_SUCCESS != ret) {


### PR DESCRIPTION
…order -

(1) rml_ofi_transports mca parameter.  This parameter should have the list of transports (currently ethernet,fabric are valid)
    fabric is higher priority if provided.
(2) ORTE_RML_TRANSPORT_TYPE key with values "ethernet" or "fabric". "fabric" is higher priority.
If specific provider is required use ORTE_RML_OFI_PROV_NAME key with values "socket" or "OPA" or any other supported in system.
	new file:   orte/mca/rml/ofi/.opal_unignore
	modified:   orte/mca/rml/ofi/rml_ofi_component.c
	modified:   orte/mca/rml/ofi/rml_ofi_send.c