### PR TITLE
btl/vader: move backing files into /dev/shm on Linux

### DIFF
--- a/opal/mca/btl/vader/btl_vader.h
+++ b/opal/mca/btl/vader/btl_vader.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Voltaire. All rights reserved.
  * Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2015 Los Alamos National Security, LLC. All rights
+ * Copyright (c) 2010-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2015      Mellanox Technologies. All rights reserved.
  *
@@ -135,6 +135,8 @@ struct mca_btl_vader_component_t {
 
     opal_list_t pending_endpoints;          /**< list of endpoints with pending fragments */
     opal_list_t pending_fragments;          /**< fragments pending remote completion */
+
+    char *backing_directory;                /**< directory to place shared memory backing files */
 
     /* knem stuff */
 #if OPAL_BTL_VADER_HAVE_KNEM

--- a/opal/mca/btl/vader/btl_vader_component.c
+++ b/opal/mca/btl/vader/btl_vader_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2007 Voltaire. All rights reserved.
  * Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
+ * Copyright (c) 2010-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2011      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
@@ -210,6 +210,19 @@ static int mca_btl_vader_component_register (void)
                                            MCA_BASE_VAR_TYPE_INT, new_enum, 0, MCA_BASE_VAR_FLAG_SETTABLE,
                                            OPAL_INFO_LVL_3, MCA_BASE_VAR_SCOPE_GROUP, &mca_btl_vader_component.single_copy_mechanism);
     OBJ_RELEASE(new_enum);
+
+    if (0 == access ("/dev/shm", W_OK)) {
+        mca_btl_vader_component.backing_directory = "/dev/shm";
+    } else {
+        mca_btl_vader_component.backing_directory = opal_process_info.proc_session_dir;
+    }
+    (void) mca_base_component_var_register (&mca_btl_vader_component.super.btl_version, "backing_directory",
+                                            "Directory to place backing files for shared memory communication. "
+                                            "This directory should be on a local filesystem such as /tmp or "
+                                            "/dev/shm (default: (linux) /dev/shm, (others) session directory)",
+                                            MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0, OPAL_INFO_LVL_3,
+                                            MCA_BASE_VAR_SCOPE_READONLY, &mca_btl_vader_component.backing_directory);
+
 
 #if OPAL_BTL_VADER_HAVE_KNEM
     /* Currently disabling DMA mode by default; it's not clear that this is useful in all applications and architectures. */
@@ -491,11 +504,15 @@ static mca_btl_base_module_t **mca_btl_vader_component_init (int *num_btls,
     if (MCA_BTL_VADER_XPMEM != mca_btl_vader_component.single_copy_mechanism) {
         char *sm_file;
 
-        rc = asprintf(&sm_file, "%s" OPAL_PATH_SEP "vader_segment.%s.%d", opal_process_info.proc_session_dir,
+        rc = asprintf(&sm_file, "%s" OPAL_PATH_SEP "vader_segment.%s.%d", mca_btl_vader_component.backing_directory,
                       opal_process_info.nodename, MCA_BTL_VADER_LOCAL_RANK);
         if (0 > rc) {
             free (btls);
             return NULL;
+        }
+
+        if (NULL != opal_pmix.register_cleanup) {
+            opal_pmix.register_cleanup (sm_file);
         }
 
         rc = opal_shmem_segment_create (&component->seg_ds, sm_file, component->segment_size);


### PR DESCRIPTION
This commit moves the backing files to /dev/shm to avoid limitations
that may be set on /tmp. The files are registered with pmix to ensure
they are cleaned up after an erroneous exit.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>